### PR TITLE
Improve Frontend Modal and Refactor Nutrient Update Logic

### DIFF
--- a/ImplementWaterCalculations.md
+++ b/ImplementWaterCalculations.md
@@ -1,0 +1,42 @@
+
+You are absolutely right! My apologies. Calculating energy density by excluding water's mass is incorrect and defeats the purpose of having a comparable Kcal/kg value. The energy density *must* reflect the total energy per total mass, including water, just as you said with the apple example.
+
+Thank you for the correction and the clear specification. Let me summarize your proposed approach to ensure I understand it correctly:
+
+**Summary of Water Calculation Specification:**
+
+1.  **Calculate Total Physiological Water Need:**
+    *   Determine the daily physiological water requirement for each `CrewMember` based on scientific estimates (using their input data like age, weight, activity, etc. - this estimation logic needs to be defined/implemented).
+    *   Sum these daily needs for all crew members to get `Total Daily Crew Water Need`.
+    *   `Total Physiological Water Need = Total Daily Crew Water Need * Adventure Days`.
+
+2.  **Calculate Total Food Provisions Weight (Standard Way):**
+    *   Calculate the `Adventure Energy Density` based on the weighted average of all meals' energy densities, correctly including *all* components (ingredients + recipe water) in both the energy and mass calculations for each meal.
+    *   Calculate `Total Food Provisions Weight = (Total Crew Kcal Need * Days) / Adventure Energy Density`.
+
+3.  **Calculate Total Water Contained Within Food:**
+    *   Distribute the `Total Food Provisions Weight` down to determine the calculated total weight of each *meal* needed for the adventure (`adventure.childWeights`).
+    *   For each meal, calculate the total weight of water it contains:
+        *   Sum the weight of *inherent* water from its ingredients (based on each ingredient's `nutrientsMap['water']` ratio and its calculated weight within the meal).
+        *   Add the weight of *explicitly added recipe water* (if water is an ingredient in the meal recipe, calculate its weight based on its recipe ratio and the total calculated meal weight).
+    *   Sum the water content across all calculated meal weights to get `Total Water Content in Food`.
+
+4.  **Calculate Required Drinking Water to Bring:**
+    *   `Required Drinking Water = Total Physiological Water Need - Total Water Content in Food`.
+    *   (Note: This could potentially be negative if the food is extremely water-rich, which might warrant special handling or a minimum value).
+
+5.  **Separately Calculate and Track Recipe Water Weight:**
+    *   Identify ingredients that *are* water within each meal's recipe.
+    *   For each meal, calculate the ratio of explicitly added recipe water relative to the meal's total recipe weight.
+    *   Calculate the total weight of explicitly added recipe water for the adventure:
+        \[ \text{weightRecipeWater} = \sum_{\text{all meals}} (\text{Calculated Total Weight of Meal} \times \text{Ratio of Added Water in Meal Recipe}) \]
+    *   This `weightRecipeWater` value should be stored (perhaps in the `Adventure` class).
+
+6.  **Display in Frontend:**
+    *   Show the `Total Food Provisions Weight`.
+    *   Display the calculated `weightRecipeWater` below the total weight, labeled something like "(of which recipe water: X.X kg)".
+    *   (Implicitly, the total water to actually *bring* would be `Required Drinking Water` + `weightRecipeWater`, though the specification focuses on displaying the recipe water component).
+
+This approach maintains the correct energy density calculation while providing a clear breakdown of physiological water needs versus water contained in the food, and specifically highlights the amount of water added during recipe preparation.
+
+Is this summary accurate to your specification?

--- a/src/main/java/io/hulsbo/MealResource.java
+++ b/src/main/java/io/hulsbo/MealResource.java
@@ -10,6 +10,7 @@ import io.hulsbo.model.Ingredient;
 import io.hulsbo.model.Manager;
 
 import java.util.Map;
+import java.util.HashMap;
 
 @Path("/meals")
 @Produces(MediaType.APPLICATION_JSON)
@@ -101,17 +102,27 @@ public class MealResource {
 				return Response.status(Response.Status.BAD_REQUEST).entity(errorMap).build();
 			}
 
-			boolean nutrientsModified = false;
+			// Create a map to hold nutrient updates
+			Map<String, Double> nutrientUpdates = new HashMap<>();
+			if (protein != null) { nutrientUpdates.put("protein", protein); }
+			if (fat != null) { nutrientUpdates.put("fat", fat); }
+			if (carbs != null) { nutrientUpdates.put("carbs", carbs); }
+			if (water != null) { nutrientUpdates.put("water", water); }
+			if (fiber != null) { nutrientUpdates.put("fiber", fiber); }
+			if (salt != null) { nutrientUpdates.put("salt", salt); }
+
+			boolean nutrientsModified = !nutrientUpdates.isEmpty();
 
 			try {
-				if (protein != null) { ingredient.setNutrientRatio("protein", protein); nutrientsModified = true; }
-				if (fat != null) { ingredient.setNutrientRatio("fat", fat); nutrientsModified = true; }
-				if (carbs != null) { ingredient.setNutrientRatio("carbs", carbs); nutrientsModified = true; }
-				if (water != null) { ingredient.setNutrientRatio("water", water); nutrientsModified = true; }
-				if (fiber != null) { ingredient.setNutrientRatio("fiber", fiber); nutrientsModified = true; }
-				if (salt != null) { ingredient.setNutrientRatio("salt", salt); nutrientsModified = true; }
+				// Apply nutrient updates in batch if any were provided
+				if (nutrientsModified) {
+					ingredient.setNutrientRatios(nutrientUpdates);
+				}
 			} catch (IllegalArgumentException e) {
-				Map<String, String> errorMap = Map.of("message", e.getMessage());
+				// Include current nutrient state in the error response
+				Map<String, Object> errorMap = new HashMap<>();
+				errorMap.put("message", e.getMessage());
+				errorMap.put("currentNutrients", ingredient.getNutrientsMap()); // Add current map
 				return Response.status(Response.Status.BAD_REQUEST).entity(errorMap).build();
 			}
 

--- a/src/main/java/io/hulsbo/model/Ingredient.java
+++ b/src/main/java/io/hulsbo/model/Ingredient.java
@@ -3,6 +3,7 @@ package io.hulsbo.model;
 import java.security.SecureRandom;
 import java.util.Set;
 import io.hulsbo.util.model.SafeID;
+import java.util.Map;
 
 public class Ingredient extends BaseClass {
 
@@ -28,7 +29,58 @@ public class Ingredient extends BaseClass {
          this.nutrientsMap.updateNutrient(nutrient, ratio); // Uses the updated put/updateNutrient logic in NutrientsMap
     }
     
-     /**
+    /**
+     * Sets multiple nutrient ratios based on the provided map.
+     * Performs validation *before* applying any changes to ensure the final sum does not exceed 100%.
+     * Does NOT trigger normalization or propagation; call normalizeNutrientRatiosAndPropagate() after successful execution.
+     *
+     * @param updates A map where keys are nutrient names and values are the new ratios (0.0 to 1.0).
+     * @throws IllegalArgumentException if any nutrient key is invalid, any value is negative, or the final sum would exceed 100%.
+     */
+    public void setNutrientRatios(Map<String, Double> updates) {
+        // 1. Validate input map keys and values
+        for (Map.Entry<String, Double> entry : updates.entrySet()) {
+            String key = entry.getKey();
+            Double value = entry.getValue();
+            if (!this.nutrientsMap.containsKey(key)) {
+                throw new IllegalArgumentException("Invalid nutrient key in updates map: " + key);
+            }
+            if (value == null || value < 0.0 || value > 1.0) { // Also check for > 1.0 here
+                 throw new IllegalArgumentException("Invalid nutrient value for key '" + key + "': " + value + ". Must be between 0.0 and 1.0.");
+            }
+        }
+
+        // 2. Calculate potential final sum
+        double potentialSum = 0.0;
+        // Start with current sum
+        for(double currentVal : this.nutrientsMap.values()) {
+            potentialSum += currentVal;
+        }
+
+        // Adjust sum based on updates
+        for (Map.Entry<String, Double> entry : updates.entrySet()) {
+            String key = entry.getKey();
+            double newValue = entry.getValue();
+            double oldValue = this.nutrientsMap.getOrDefault(key, 0.0); // Get current value
+            potentialSum = potentialSum - oldValue + newValue; // Adjust sum
+        }
+
+        // 3. Validate potential final sum
+        double TOLERANCE = 1e-9; // Use the same tolerance as NutrientsMap
+        if (potentialSum > 1.0 + TOLERANCE) {
+            throw new IllegalArgumentException(String.format(
+                "Updating nutrients would exceed 100%%. Final sum would be %.1f%%.",
+                potentialSum * 100));
+        }
+
+        // 4. If valid, apply all updates
+        for (Map.Entry<String, Double> entry : updates.entrySet()) {
+             // Use internalPut to bypass the individual sum check within NutrientsMap.put
+             this.nutrientsMap.internalPut(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
      * Normalizes the nutrient ratios in the Ingredient's NutrientsMap so they sum to 1.0,
      * recalculates energy density, and propagates updates to parent objects.
      * Should be called after one or more calls to setNutrientRatio().

--- a/src/main/resources/META-INF/resources/demo/index.html
+++ b/src/main/resources/META-INF/resources/demo/index.html
@@ -299,10 +299,6 @@
                 </div>
                 <div class="input-row">
                     <div class="input-group">
-                        <label for="modalIngredientWater">Water</label>
-                        <input type="number" id="modalIngredientWater" min="0" max="100" step="0.1" value="0">
-                    </div>
-                    <div class="input-group">
                         <label for="modalIngredientFiber">Fiber</label>
                         <input type="number" id="modalIngredientFiber" min="0" max="100" step="0.1" value="0">
                     </div>
@@ -310,12 +306,17 @@
                         <label for="modalIngredientSalt">Salt</label>
                         <input type="number" id="modalIngredientSalt" min="0" max="100" step="0.1" value="0">
                     </div>
+                    <div class="input-group">
+                        <label for="modalIngredientWater">Water</label>
+                        <input type="number" id="modalIngredientWater" min="0" max="100" step="0.1" value="0" disabled title="Autofills with the remaining %">
+                    </div>
                 </div>
             </div>
             
             <!-- Modal Footer: Feedback and Button -->
             <div class="modal-footer">
                 <p id="modalIngredientFeedback" class="modal-feedback" aria-live="polite"></p> 
+                <button id="modalResetButton" onclick="resetModalFieldsToLastValidState()" class="modal-reset-button">Reset Fields</button>
                 <button onclick="updateIngredient()" class="modal-add-button">Update Ingredient</button>
             </div>
         </div>

--- a/src/main/resources/META-INF/resources/demo/styles.css
+++ b/src/main/resources/META-INF/resources/demo/styles.css
@@ -571,6 +571,13 @@ button:hover {
     box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
 }
 
+/* Style for disabled inputs in modal */
+.modal input:disabled {
+    background-color: #e9ecef; /* Light grey background */
+    cursor: not-allowed; /* Indicate non-interactive */
+    opacity: 0.7; /* Slightly faded */
+}
+
 /* Modal Footer Styling */
 .modal-footer {
     display: flex;
@@ -610,13 +617,21 @@ button:hover {
     flex-shrink: 0; /* Prevent button from shrinking */
 }
 
-/* Input Highlighting */
-.modal input.input-increased {
-    border-color: #28a745; /* Green */
-    box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25);
+/* Style for the new reset button */
+.modal-footer .modal-reset-button {
+    margin: 0 10px 0 0; /* Add some space to its right */
+    background-color: #007bff; /* Primary blue */
+    color: white; /* White text */
+    flex-shrink: 0;
+    /* Inherit padding, border-radius etc. from general button style if defined */
+    /* If not, uncomment and adjust these: */
+    /* padding: 8px 15px; */
+    /* border: none; */
+    /* border-radius: 4px; */
+    /* cursor: pointer; */
+    /* font-size: 0.9em; */
 }
 
-.modal input.input-decreased {
-    border-color: #dc3545; /* Red */
-    box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
+.modal-footer .modal-reset-button:hover {
+    background-color: #0056b3; /* Darker blue on hover */
 } 

--- a/src/test/java/io/hulsbo/util/model/baseclass/NutrientsMapTest.java
+++ b/src/test/java/io/hulsbo/util/model/baseclass/NutrientsMapTest.java
@@ -60,15 +60,18 @@ public class NutrientsMapTest {
         nutrientsMap.put("protein", 0.5);
         nutrientsMap.put("fat", 0.5); // Sum = 1.0
         
-        nutrientsMap.put("protein", 0.7); // Increase protein, should steal 0.2 from fat
+        // Now, attempting to increase protein should throw an exception
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            nutrientsMap.put("protein", 0.7); // Increase protein, would need to steal 0.2 from fat
+        });
         
-        assertEquals(0.7, nutrientsMap.get("protein"), TOLERANCE);
-        // Fat was 0.5. Other sum was 0.5. Increase was 0.2.
-        // Scale factor = (0.5 - 0.2) / 0.5 = 0.3 / 0.5 = 0.6
-        // New fat = 0.5 * 0.6 = 0.3
-        assertEquals(0.3, nutrientsMap.get("fat"), TOLERANCE);
-        assertEquals(0.0, nutrientsMap.get("carbs"), TOLERANCE);
-        assertEquals(1.0, nutrientsMap.values().stream().mapToDouble(Double::doubleValue).sum(), TOLERANCE); // Verify sum is still 1.0
+        // Verify the exception message (optional but good)
+        assertTrue(exception.getMessage().contains("Cannot set protein to 70.0%"));
+        assertTrue(exception.getMessage().contains("Overshoot by  20.0%"));
+        
+        // Verify state did not change
+        assertEquals(0.5, nutrientsMap.get("protein"), TOLERANCE);
+        assertEquals(0.5, nutrientsMap.get("fat"), TOLERANCE);
     }
     
     @Test
@@ -77,16 +80,18 @@ public class NutrientsMapTest {
         nutrientsMap.put("fat", 0.4);
         nutrientsMap.put("carbs", 0.2); // Sum = 1.0
         
-        nutrientsMap.put("protein", 0.7); // Increase protein by 0.3, steal from fat and carbs
-        
-        assertEquals(0.7, nutrientsMap.get("protein"), TOLERANCE);
-        // Other sum = 0.4 (fat) + 0.2 (carbs) = 0.6. Increase = 0.3.
-        // Scale factor = (0.6 - 0.3) / 0.6 = 0.3 / 0.6 = 0.5
-        // New fat = 0.4 * 0.5 = 0.2
-        // New carbs = 0.2 * 0.5 = 0.1
-        assertEquals(0.2, nutrientsMap.get("fat"), TOLERANCE);
-        assertEquals(0.1, nutrientsMap.get("carbs"), TOLERANCE);
-        assertEquals(1.0, nutrientsMap.values().stream().mapToDouble(Double::doubleValue).sum(), TOLERANCE);
+        // Now, attempting to increase protein should throw an exception
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+             nutrientsMap.put("protein", 0.7); // Increase protein by 0.3, would steal from fat and carbs
+        });
+
+        assertTrue(exception.getMessage().contains("Cannot set protein to 70.0%"));
+        assertTrue(exception.getMessage().contains("Overshoot by  30.0%"));
+
+        // Verify state did not change
+        assertEquals(0.4, nutrientsMap.get("protein"), TOLERANCE);
+        assertEquals(0.4, nutrientsMap.get("fat"), TOLERANCE);
+        assertEquals(0.2, nutrientsMap.get("carbs"), TOLERANCE);
     }
 
     @Test
@@ -94,14 +99,20 @@ public class NutrientsMapTest {
         nutrientsMap.put("protein", 0.8);
         nutrientsMap.put("fat", 0.2); // Sum = 1.0
         
-        // Try to increase protein by 0.3 (to 1.1), but can only steal 0.2 from fat.
-        nutrientsMap.put("protein", 1.1); // Input gets clamped to 1.0 first
+        // Try to increase protein by 0.3 (to 1.1).
+        // Input gets clamped to 1.0 first inside put().
+        // Then the potentialSum check runs: current(1.0) - old(0.8) + newClamped(1.0) = 1.2
+        // This exceeds 1.0, so it should throw.
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            nutrientsMap.put("protein", 1.1); 
+        });
+
+        assertTrue(exception.getMessage().contains("Cannot set protein to 100.0%"));
+        assertTrue(exception.getMessage().contains("Overshoot by  20.0%")); // 1.2 is 0.2 over 1.0
         
-        // Because increase (1.0 - 0.8 = 0.2) >= otherSum (0.2), protein becomes 1.0, fat becomes 0.0
-        assertEquals(1.0, nutrientsMap.get("protein"), TOLERANCE);
-        assertEquals(0.0, nutrientsMap.get("fat"), TOLERANCE);
-        assertEquals(0.0, nutrientsMap.get("carbs"), TOLERANCE);
-        assertEquals(1.0, nutrientsMap.values().stream().mapToDouble(Double::doubleValue).sum(), TOLERANCE);
+        // Verify state did not change
+        assertEquals(0.8, nutrientsMap.get("protein"), TOLERANCE);
+        assertEquals(0.2, nutrientsMap.get("fat"), TOLERANCE);
     }
     
     @Test
@@ -163,31 +174,22 @@ public class NutrientsMapTest {
 
     @Test
     void testUpdateNutrientSameAsPut() {
-        // Test that updateNutrient triggers stealing like put does
+        // Test that updateNutrient throws when put() would
         nutrientsMap.updateNutrient("protein", 0.6);
         nutrientsMap.updateNutrient("fat", 0.4); // Sum = 1.0
         
-        // Now try to update carbs, which should steal from protein and fat
-        nutrientsMap.updateNutrient("carbs", 0.1); // Increase by 0.1, steal from protein (0.6) and fat (0.4)
-        
-        // Other sum = 0.6 + 0.4 = 1.0. Increase = 0.1
-        // Scale factor = (1.0 - 0.1) / 1.0 = 0.9
-        // New protein = 0.6 * 0.9 = 0.54
-        // New fat = 0.4 * 0.9 = 0.36
-        // New carbs = 0.1
-        assertEquals(0.54, nutrientsMap.get("protein"), TOLERANCE);
-        assertEquals(0.36, nutrientsMap.get("fat"), TOLERANCE);
-        assertEquals(0.1, nutrientsMap.get("carbs"), TOLERANCE);
-        assertEquals(1.0, nutrientsMap.values().stream().mapToDouble(Double::doubleValue).sum(), TOLERANCE);
-        
-        // Test invalid key and negative value (should still throw)
-         assertThrows(IllegalArgumentException.class, () -> {
-             nutrientsMap.updateNutrient("protein", -0.1);
-         });
-         
-         assertThrows(IllegalArgumentException.class, () -> {
-            nutrientsMap.updateNutrient("unknown", 0.1);
+        // Now try to update carbs, potentialSum = 1.0 - 0.0 + 0.1 = 1.1 > 1.0
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+             nutrientsMap.updateNutrient("carbs", 0.1); 
         });
+
+        assertTrue(exception.getMessage().contains("Cannot set carbs to 10.0%"));
+        assertTrue(exception.getMessage().contains("Overshoot by  10.0%"));
+        
+        // Verify state didn't change
+        assertEquals(0.6, nutrientsMap.get("protein"), TOLERANCE);
+        assertEquals(0.4, nutrientsMap.get("fat"), TOLERANCE);
+        assertEquals(0.0, nutrientsMap.get("carbs"), TOLERANCE);
     }
 
     @Test


### PR DESCRIPTION

Okay, here is a suggested Pull Request description summarizing the changes made:

---

**Title:** Refactor Nutrient Update Logic and Improve Frontend Modal UX

**Description:**

This PR addresses issues related to updating ingredient nutrients, focusing on providing stricter validation on the backend and a clearer, more robust user experience in the frontend "Modify Ingredient" modal. The previous implementation allowed intermediate nutrient sums to exceed 100% during sequential updates, leading to confusing errors, and employed nutrient "stealing" logic which was not the desired behavior.

**Changes Made:**

**Backend (Core Logic - `Ingredient`, `NutrientsMap`):**

*   **Removed Nutrient Stealing:** Removed the logic in `NutrientsMap.put` that would proportionally reduce other nutrients ("steal") when an update caused the sum to exceed 100%.
*   **Strict `NutrientsMap` Validation:** `NutrientsMap.put` now throws an `IllegalArgumentException` immediately if an *individual* update would cause the nutrient ratio sum to exceed 100%, preventing invalid intermediate states.
*   **Added Batch Nutrient Update (`Ingredient.setNutrientRatios`):** Introduced a new method in `Ingredient` that accepts a map of nutrient updates. This method validates the *final potential sum* of all requested changes *before* applying any of them.
*   **Bypass for Batch Application (`NutrientsMap.internalPut`):** Added a public `internalPut` method to `NutrientsMap` that bypasses the individual sum check. This is used exclusively by `Ingredient.setNutrientRatios` *after* the batch validation has succeeded, preventing redundant checks during the application phase.
*   **Improved Error Formatting:** Updated `IllegalArgumentException` messages in `NutrientsMap` to use percentages and `Locale.US` formatting for consistency and clarity.

**Backend (API - `MealResource`):**

*   **Adopted Batch Updates:** Modified the `PUT /meals/{mealId}/ingredients/{ingredientId}` endpoint to use the new `Ingredient.setNutrientRatios` method, ensuring atomic validation of nutrient changes.
*   **Enhanced Error Response:** Updated the 400 Bad Request response for nutrient validation errors to return a JSON object containing both the error `message` and the `currentNutrients` map (representing the ingredient's state before the failed update attempt).

**Frontend (Modify Ingredient Modal - `index.html`, `styles.css`, `script.js`):**

*   **Automated Water Calculation:** The "Water" input field is now disabled and automatically calculated based on the values of other nutrients (Protein, Fat, Carbs, Fiber, Salt) to always sum to 100% within the modal.
*   **Improved Error Handling:**
    *   The `updateIngredient` function now correctly parses the enhanced JSON error response from the backend.
    *   Displays the specific error `message` from the backend.
    *   When an error response includes `currentNutrients`, the modal fields are automatically reset to reflect this last known valid state from the server.
*   **"Reset Fields" Button:**
    *   Added an always-visible "Reset Fields" button to the modal footer with distinct styling.
    *   Clicking "Reset" prioritizes reverting the fields to the state provided in the *last error response* (`lastValidNutrientsOnError`). If no error state is stored, it reverts to the state when the modal was initially opened (`previousIngredientModalState`).

**Tests (`NutrientsMapTest.java`, `MealResourceTest.java`):**

*   Updated tests previously asserting "stealing" or "clamping" behavior in `NutrientsMap` to now assert that the appropriate `IllegalArgumentException` is thrown.
*   Updated `MealResource` tests to expect 400 Bad Request status codes for invalid nutrient updates and to verify the content of the new JSON error response format (`message` field).

**How to Test:**

1.  Open the "Modify Ingredient" modal.
2.  Attempt to update nutrients such that the final sum exceeds 100%. Verify a 400 error occurs, the specific error message is shown, and the fields automatically reset to their state before the failed update.
3.  Make valid changes to nutrients and click "Update Ingredient". Verify success.
4.  Open the modal, make changes (valid or invalid), and click "Reset Fields". Verify the fields revert to the expected state (either the state from the last error, or the state when the modal was opened).
5.  Verify the Water field updates automatically as other nutrient fields are changed.

---
